### PR TITLE
Remove feetPosition calculation

### DIFF
--- a/src/game_objects/player.ts
+++ b/src/game_objects/player.ts
@@ -35,8 +35,6 @@ export class Player implements ICollidable {
   private ballInteractionMediator?: IPlayerBallInteractionMediator;
   private role?: PlayerRole;
 
-  private lastNonZeroVelocity: ThreeDimensionalVector;
-
   constructor(x: number, y: number, vx: number, vy: number, diameter: number) {
       this.id = v4(); // Randomly generated id
       this.x = x;
@@ -48,9 +46,6 @@ export class Player implements ICollidable {
       // Like a PhysicalRepresentation or something like that. So that we can
       // swap representations out as we see fit.
       this.colors = [0, 0, 225];
-
-      // HACK: Prevent last non zero velocity from starting off null.
-      this.lastNonZeroVelocity = new ThreeDimensionalVector(1, 0, 0);
   }
 
   public update(): void {
@@ -84,10 +79,8 @@ export class Player implements ICollidable {
   }
 
   public feetPosition(): ThreeDimensionalVector {
-    const margin = this.diameter / 2;
-    return this.lastNonZeroVelocity.unit()
-      .scalarMultiply(margin)
-      .add(this.getPosition());
+    // TODO: Actually properly calculate feetPosition
+    return this.getPosition();
   }
 
   public moveTowards(target: ThreeDimensionalVector): void {
@@ -275,9 +268,5 @@ export class Player implements ICollidable {
 
   private setVelocity(velocity: ThreeDimensionalVector) {
     [this.vx, this.vy] = [velocity.x, velocity.y];
-
-    if (velocity.isNonZero()) {
-      this.lastNonZeroVelocity = velocity;
-    }
   }
 }

--- a/tests/game_objects/player_test.ts
+++ b/tests/game_objects/player_test.ts
@@ -72,32 +72,6 @@ describe('Player', () => {
     });
   });
 
-  describe('`feetPosition`', () => {
-    it('returns the unit of the last non-zero velocity scaled by player' +
-      ' radius offset by current position', () => {
-        const player = new Player(3, 6, 0, 0, 5);
-        player.setMaximumSpeed(10);
-        player.moveUp();
-        player.stop();
-
-        const position = player.feetPosition();
-        const expectedPosition = new ThreeDimensionalVector(3, 3.5, 0);
-        expect(position.equals(expectedPosition)).to.be.true;
-      });
-
-    it('returns the unit of the last non-zero velocity scaled by player' +
-      ' radius offset by current position', () => {
-        const player = new Player(3, 6, 0, 0, 5);
-        player.setMaximumSpeed(10);
-        player.moveTowards(new ThreeDimensionalVector(13, 6, 0));
-        player.stop();
-
-        const position = player.feetPosition();
-        const expectedPosition = new ThreeDimensionalVector(5.5, 6, 0);
-        expect(position.equals(expectedPosition)).to.be.true;
-      });
-  });
-
   describe('`kickBall`', () => {
     it('calls `kickBall` on the ballInteractionMediator', () => {
       const player = new Player(0, 0, 0, 0, 5);


### PR DESCRIPTION
It's not that important for the ball to be positioned at the feet of the player, as of now. When we have real sprites, perhaps it would make more sense. Deleting this code to prevent 'Nan' values from being set on the ball.