### PR TITLE
Continuous congestion score

### DIFF
--- a/src/game_ai/player/state_machine/calculators/congestion_calculator.ts
+++ b/src/game_ai/player/state_machine/calculators/congestion_calculator.ts
@@ -1,5 +1,6 @@
 import { Player } from "../../../../../src/game_objects/player";
 import { ThreeDimensionalVector } from "../../../../../src/three_dimensional_vector";
+import { scale } from "../../../../utils/helper_functions";
 
 export class CongestionCalculator {
   private players: Player[];
@@ -11,8 +12,17 @@ export class CongestionCalculator {
   }
 
   public evaluate(position: ThreeDimensionalVector): number {
-    return this.players.filter((player) => {
-      return player.getPosition().distanceTo(position) <= this.radiusOfInterest;
-    }).length;
+    return this.players.reduce((totalCongestion, player) => {
+      totalCongestion += this.individualContributionToCongestion(
+        player, position);
+      return totalCongestion;
+    }, 0);
   }
+
+  private individualContributionToCongestion(
+    player: Player, position: ThreeDimensionalVector): number {
+      const distance = player.getPosition().distanceTo(position);
+      if (distance >= this.radiusOfInterest) { return 0; }
+      return scale(distance, 0, this.radiusOfInterest, 1, 0);
+    }
 }

--- a/src/position_value_calculator.ts
+++ b/src/position_value_calculator.ts
@@ -25,6 +25,7 @@ export class PositionValueCalculator implements IPositionValueCalculator {
   }
 
   public evaluate(player: Player, position: ThreeDimensionalVector): number {
+    // TODO: Use a more fluent way to check if a position is within the bounds
     if (!this.field.containsCircle(position.x, position.y, 0.001)) {
       return 0;
     }
@@ -34,6 +35,7 @@ export class PositionValueCalculator implements IPositionValueCalculator {
     const trackingBall = this.trackingBallScore(player, position);
 
     const weightedScore =
+      // TODO: Make these weights constants
       (congestion * 0.4) + (shotValue * 0.4) + (trackingBall * 0.2);
     return round(weightedScore, 2);
   }
@@ -42,6 +44,7 @@ export class PositionValueCalculator implements IPositionValueCalculator {
     player: Player, position: ThreeDimensionalVector): number {
       const congestion = this.congestionCalculator.evaluate(position);
       const congestionInverse = 1 / congestion;
+      // Make this cutoff a constant
       const score = congestionInverse >= 0.2 ? congestionInverse : 0;
       return score;
   }


### PR DESCRIPTION
# What's Up
There was a small bug where, despite factoring congestion into position value, players would literally sit on each other. This is because our previous calculation for congestion only took into account the number of players within a given radius, and not their cumulative distance from the reference position. 

As a result if two players were in the exact same position, and one of them is considering x other locations to visit, all of which were still within the congestion calculator radius of interest, it would seem like neither of those positions were less congested (Although indeed they could be since each one may be nearer or closer to the other player).

This change takes distance into account and solves that problem.