### PR TITLE
Move player messages to Player class

### DIFF
--- a/src/game_ai/player/human_controller/player_human_controller.ts
+++ b/src/game_ai/player/human_controller/player_human_controller.ts
@@ -29,10 +29,6 @@ export class PlayerHumanController implements IPlayerController {
     }
   }
 
-  public handleMessage(message: {details: string}): void {
-    return;
-  }
-
   public enable(): void {
     this.enabled = true;
   }

--- a/src/game_ai/player/state_machine/player_state_feature_extractor.ts
+++ b/src/game_ai/player/state_machine/player_state_feature_extractor.ts
@@ -1,4 +1,4 @@
-import { POSITION_DELTA_FOR_POSITION_VALUE_CALCULATION } from "../../../constants";
+import { POSITION_DELTA_FOR_POSITION_VALUE_CALCULATION, STATE_MACHINE_COMMANDS } from "../../../constants";
 import { Ball } from "../../../game_objects/ball";
 import { Player } from "../../../game_objects/player";
 import { IBallPossessionService } from "../../../interfaces/iball_possession_service";
@@ -10,23 +10,12 @@ import { Vector3D } from "../../../three_dimensional_vector";
 import { maximumBy, minimumBy } from "../../../utils/helper_functions";
 
 export class PlayerStateFeatureExtractor implements IPlayerStateFeatureExtractor {
-  private ball: Ball;
-  private ballPossessionService: IBallPossessionService;
-  private passValueCalculator: IPassValueCalculator;
-  private shotValueCalculator: IShotValueCalculator;
-  private positionValueCalculator: IPositionValueCalculator;
-
   constructor(
-    ball: Ball,
-    ballPossessionService: IBallPossessionService,
-    passValueCalculator: IPassValueCalculator,
-    shotValueCalculator: IShotValueCalculator,
-    positionValueCalculator: IPositionValueCalculator) {
-      this.ball = ball;
-      this.ballPossessionService = ballPossessionService;
-      this.passValueCalculator = passValueCalculator;
-      this.shotValueCalculator = shotValueCalculator;
-      this.positionValueCalculator = positionValueCalculator;
+    private ball: Ball,
+    private ballPossessionService: IBallPossessionService,
+    private passValueCalculator: IPassValueCalculator,
+    private shotValueCalculator: IShotValueCalculator,
+    private positionValueCalculator: IPositionValueCalculator) {
   }
 
   public teamInControl(player: Player): boolean {
@@ -82,5 +71,9 @@ export class PlayerStateFeatureExtractor implements IPlayerStateFeatureExtractor
     });
 
     return closestTeamMate === player;
+  }
+
+  public receivedWaitMessage(player: Player): boolean {
+    return player.readAllMessages().includes(STATE_MACHINE_COMMANDS.WAIT);
   }
 }

--- a/src/game_ai/player/state_machine/player_state_machine.ts
+++ b/src/game_ai/player/state_machine/player_state_machine.ts
@@ -25,28 +25,10 @@ export class PlayerStateMachine implements IPlayerController {
   public update() {
     if (!this.enabled) { return; }
 
-    const features = this.getFeatures();
+    const features = this.getFeatures(this.player);
     const eligibleState = this.states.find(
         (state) => state.eligibleFor(features));
     eligibleState.update(this.player, features);
-  }
-
-  public handleMessage(message: {details: string}): void {
-    const instruction = message.details;
-
-    if (instruction === STATE_MACHINE_COMMANDS.WAIT) {
-      this.messages.push(instruction);
-      return;
-    }
-
-    if (instruction === STATE_MACHINE_COMMANDS.NO_NEED_TO_WAIT) {
-      this.clearWaitMessages();
-      return;
-    }
-  }
-
-  public getMessages() {
-    return [...this.messages];
   }
 
   public setFeatureExtractor(extractor: IPlayerStateFeatureExtractor) {
@@ -61,24 +43,15 @@ export class PlayerStateMachine implements IPlayerController {
     this.enabled = false;
   }
 
-  private getFeatures(): IPlayerStateFeature {
+  private getFeatures(player: Player): IPlayerStateFeature {
     return {
-      bestPassingOption: this.extractor.bestPassingOption(this.player),
-      bestPositionOption: this.extractor.bestPositionOption(this.player),
-      hasBall: this.extractor.hasBall(this.player),
-      hasWaitMessages: this.hasWaitMessages(),
-      isNearestTeamMateToBall: this.extractor.isNearestTeamMateToBall(this.player),
-      shotValue: this.extractor.shotValue(this.player),
-      teamInControl: this.extractor.teamInControl(this.player),
+      bestPassingOption: this.extractor.bestPassingOption(player),
+      bestPositionOption: this.extractor.bestPositionOption(player),
+      hasBall: this.extractor.hasBall(player),
+      hasWaitMessages: this.extractor.receivedWaitMessage(player),
+      isNearestTeamMateToBall: this.extractor.isNearestTeamMateToBall(player),
+      shotValue: this.extractor.shotValue(player),
+      teamInControl: this.extractor.teamInControl(player),
     };
-  }
-
-  private hasWaitMessages(): boolean {
-    return this.messages.includes(STATE_MACHINE_COMMANDS.WAIT);
-  }
-
-  private clearWaitMessages(): void {
-    this.messages = this.messages.filter(
-      (message) => message !== STATE_MACHINE_COMMANDS.WAIT);
   }
 }

--- a/src/game_ai/player/state_machine/waiting_state.ts
+++ b/src/game_ai/player/state_machine/waiting_state.ts
@@ -13,24 +13,14 @@ export class WaitingState implements IPlayerState {
   }
 
   public eligibleFor(features: IPlayerStateFeature): boolean {
-    return features.hasWaitMessages;
+    const waitingNoLongerValid = features.hasBall || !features.teamInControl;
+    return features.hasWaitMessages && !waitingNoLongerValid;
   }
 
   public update(player: Player, features: IPlayerStateFeature): void {
-    if (!this.eligibleFor(features)) {
-      return;
-    }
+    if (!this.eligibleFor(features)) { return; }
 
-    if (this.waitingNoLongerValidFor(features)) {
-      player.sendMessage(player,
-        {details: STATE_MACHINE_COMMANDS.NO_NEED_TO_WAIT});
-      return;
-    }
-
+    player.sendMessage(player, {details: STATE_MACHINE_COMMANDS.WAIT});
     this.commandFactory.getCommand(COMMAND_ID.STOP).execute(player);
-  }
-
-  private waitingNoLongerValidFor(features: IPlayerStateFeature): boolean {
-    return features.hasBall || !features.teamInControl;
   }
 }

--- a/src/game_objects/player.ts
+++ b/src/game_objects/player.ts
@@ -34,6 +34,7 @@ export class Player implements ICollidable {
   private messageQueue?: EventQueue;
   private ballInteractionMediator?: IPlayerBallInteractionMediator;
   private role?: PlayerRole;
+  private messages: string[];
 
   constructor(x: number, y: number, vx: number, vy: number, diameter: number) {
       this.id = v4(); // Randomly generated id
@@ -46,6 +47,7 @@ export class Player implements ICollidable {
       // Like a PhysicalRepresentation or something like that. So that we can
       // swap representations out as we see fit.
       this.colors = [0, 0, 225];
+      this.messages = [];
   }
 
   public update(): void {
@@ -240,6 +242,16 @@ export class Player implements ICollidable {
     this.ballInteractionMediator.chaseBall(this);
   }
 
+  public getMessages(): string[] {
+    return [...this.messages];
+  }
+
+  public readAllMessages(): string[] {
+    const messages = this.messages;
+    this.messages = [];
+    return messages;
+  }
+
   private attackingPosition(): Vector3D {
     return this.role.getDefaultAttackingPosition(this.team.getSide());
   }
@@ -255,7 +267,7 @@ export class Player implements ICollidable {
   private listenForMessages(): void {
     this.messageQueue.when(
       `player.${this.id}.messaged`, (message: {details: string}) => {
-        this.controller.handleMessage(message);
+        this.messages.push(message.details);
       });
   }
 

--- a/src/interfaces/iplayer_controller.ts
+++ b/src/interfaces/iplayer_controller.ts
@@ -1,6 +1,5 @@
 export interface IPlayerController {
   update(): void;
-  handleMessage(message: {details: string}): void;
   enable(): void;
   disable(): void;
 }

--- a/src/interfaces/iplayer_state_feature_extractor.ts
+++ b/src/interfaces/iplayer_state_feature_extractor.ts
@@ -6,6 +6,7 @@ export interface IPlayerStateFeatureExtractor {
   bestPositionOption(player: Player): Vector3D;
   hasBall(player: Player): boolean;
   isNearestTeamMateToBall(player: Player): boolean;
+  receivedWaitMessage(player: Player): boolean;
   shotValue(player: Player): number;
   teamInControl(player: Player): boolean;
 }

--- a/tests/game_ai/player/state_machine/player_state_feature_extractor_test.ts
+++ b/tests/game_ai/player/state_machine/player_state_feature_extractor_test.ts
@@ -9,7 +9,7 @@ import { TestBallPossessionService } from '../../../helpers/test_ball_possession
 import { Vector3D } from '../../../../src/three_dimensional_vector';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
-import { COMMAND_ID } from '../../../../src/constants';
+import { COMMAND_ID, STATE_MACHINE_COMMANDS } from '../../../../src/constants';
 
 const sinonChai = require('sinon-chai');
 const expect = chai.expect;
@@ -162,6 +162,37 @@ describe('PlayerStateFeatureExtractor', () => {
         );
 
         expect(extractor.isNearestTeamMateToBall(otherPlayer)).to.be.false;
+    });
+  });
+
+  describe('`receivedWaitMessage`', () => {
+    it('returns true if the player has WAIT messages', () => {
+      sinon.stub(player, 'readAllMessages').returns(
+        [STATE_MACHINE_COMMANDS.WAIT]);
+      const possessionService = new TestBallPossessionService();
+      const extractor = new PlayerStateFeatureExtractor(
+        ball,
+        possessionService,
+        passValueCalculator,
+        shotValueCalculator,
+        positionValueCalculator
+      );
+
+      expect(extractor.receivedWaitMessage(player)).to.be.true;
+    });
+
+    it('returns false if the player does not have WAIT messages', () => {
+      sinon.stub(player, 'getMessages').returns([]);
+      const possessionService = new TestBallPossessionService();
+      const extractor = new PlayerStateFeatureExtractor(
+        ball,
+        possessionService,
+        passValueCalculator,
+        shotValueCalculator,
+        positionValueCalculator
+      );
+
+      expect(extractor.receivedWaitMessage(player)).to.be.false;
     });
   });
 });

--- a/tests/game_ai/player/state_machine/player_state_machine_test.ts
+++ b/tests/game_ai/player/state_machine/player_state_machine_test.ts
@@ -20,6 +20,7 @@ let extractor = {
   isNearestTeamMateToBall: (player: Player) => false,
   shotValue: (player: Player) => 0,
   teamInControl: (player: Player) => false,
+  receivedWaitMessage: (player: Player) => false,
 };
 
 describe('PlayerStateMachine', () => {
@@ -66,48 +67,6 @@ describe('PlayerStateMachine', () => {
 
       expect(ineligibleStateSpy).not.to.have.been.called;
       expect(eligibleStateSpy).to.have.been.calledWith(player, features);
-    });
-  });
-
-  describe('`handleMessage`', () => {
-    it('pushes a WAIT message unto `messages`', () => {
-      const stateA = {
-        eligibleFor: (features: IPlayerStateFeature) => { return false },
-        update: (player: Player, features: IPlayerStateFeature) => {},
-      };
-
-      const stateB = {
-        eligibleFor: (features: IPlayerStateFeature) => { return true },
-        update: (player: Player, features: IPlayerStateFeature) => {},
-      };
-
-      const machine = new PlayerStateMachine(player, [stateA, stateB]);
-      machine.setFeatureExtractor(extractor);
-      machine.handleMessage({details: STATE_MACHINE_COMMANDS.WAIT});
-
-      expect(machine.getMessages()).to.eql([STATE_MACHINE_COMMANDS.WAIT]);
-    });
-
-    it('removes WAIT messages when a NO_NEED_TO_WAIT message is received',
-      () => {
-        const stateA = {
-          eligibleFor: (features: IPlayerStateFeature) => { return false },
-          update: (player: Player, features: IPlayerStateFeature) => {},
-        };
-
-        const stateB = {
-          eligibleFor: (features: IPlayerStateFeature) => { return true },
-          update: (player: Player, features: IPlayerStateFeature) => {},
-        };
-
-        const machine = new PlayerStateMachine(player, [stateA, stateB]);
-        machine.setFeatureExtractor(extractor);
-        machine.handleMessage({details: STATE_MACHINE_COMMANDS.WAIT});
-        machine.handleMessage({details: STATE_MACHINE_COMMANDS.WAIT});
-        machine.handleMessage(
-            {details: STATE_MACHINE_COMMANDS.NO_NEED_TO_WAIT});
-
-        expect(machine.getMessages()).to.eql([]);
     });
   });
 });

--- a/tests/game_objects/player_test.ts
+++ b/tests/game_objects/player_test.ts
@@ -1,6 +1,5 @@
 import { Ball } from '../../src/game_objects/ball';
 import { Player } from '../../src/game_objects/player';
-import { IPlayerController } from '../../src/interfaces/iplayer_controller';
 import { IPlayerBallInteractionMediator } from '../../src/interfaces/iplayer_ball_interaction_mediator';
 import { Team } from '../../src/game_objects/team';
 import { EventQueue } from '../../src/event_queue';
@@ -49,26 +48,15 @@ describe('Player', () => {
   });
 
   describe('`setMessageQueue`', () => {
-    it('passes player messages to its controller', () => {
-      class TestController implements IPlayerController {
-        update() {}
-        handleMessage(message: {details: string}) {}
-        enable() {}
-        disable() {}
-      }
-
+    it('stores messages', () => {
       const queue = new EventQueue();
       const player = new Player(0, 0, 0, 0, 5);
-      const controller = new TestController();
-      player.setController(controller);
       player.setMessageQueue(queue);
-      sinon.spy(controller, 'handleMessage');
 
       queue.trigger(`player.${player.getGameObjectId()}.messaged`,
         {details: 'message'});
 
-      expect(controller.handleMessage).to.have.been.calledWith(
-        {details: 'message'});
+      expect(player.getMessages()).to.eql(['message']);
     });
   });
 


### PR DESCRIPTION
First phase of refactoring PlayerStateFeatureExtractor: Move messages unto the player class and then let them be read by the FeatureExtractor. 

Concerns: Unless the StateMachine reads the messages they will pile up continuously in the Player instance. We could set a timeout on each message to remove it from the array if that ever became a problem.