### PR TITLE
fix errors raised from tracking multiple shots

### DIFF
--- a/src/services/ball_possession_service.ts
+++ b/src/services/ball_possession_service.ts
@@ -57,8 +57,8 @@ export class BallPossessionService implements IBallPossessionService {
 
     if (!playerInPossession) { return; }
 
+    this.publishPossesionChangedEvents(playerInPossession);
     this.currentPlayerInPossession = playerInPossession;
-    this.publishPossesionChangedEvents();
     this.lastPlayerInPossession = playerInPossession;
   }
 
@@ -66,12 +66,10 @@ export class BallPossessionService implements IBallPossessionService {
     return this.constructor.name;
   }
 
-  private publishPossesionChangedEvents(): void {
-    if (!this.lastPlayerInPossession) { return; }
-
-    if (this.currentPlayerInPossession !== this.lastPlayerInPossession) {
+  private publishPossesionChangedEvents(playerInPossession: Player): void {
+    if (!this.currentPlayerInPossession) {
       this.queue.trigger(
-        `${this.eventTag()}.possessionChanged`, this.currentPlayerInPossession);
+          `${this.eventTag()}.possessionChanged`, playerInPossession);
     }
   }
 }

--- a/src/stats/pass_tracker_service.ts
+++ b/src/stats/pass_tracker_service.ts
@@ -12,7 +12,7 @@ export class PassTrackerService {
     private ballPossessionService: IBallPossessionService) { }
 
   public setup(): void {
-    if (this.enabled) return;
+    if (this.enabled) { return; }
     this.listenForPossessionChange();
     this.enabled = true;
   }
@@ -45,7 +45,7 @@ export class PassTrackerService {
 
   private listenForPossessionChange(): void {
     this.ballPossessionService.whenPossessionChanged((playerInPossession) => {
-      if (!this.currentlyTrackedPass) return;
+      if (!this.currentlyTrackedPass) { return; }
       this.recordPassCompletion(playerInPossession);
     });
   }

--- a/src/stats/shot_tracker_service.ts
+++ b/src/stats/shot_tracker_service.ts
@@ -14,7 +14,7 @@ export class ShotTrackerService {
     private goalDetectionService: GoalDetectionService) { }
 
     public setup(): void {
-      if (this.enabled) return;
+      if (this.enabled) { return; }
 
       this.listenForGoals();
       this.listenForPossessionChange();
@@ -33,7 +33,7 @@ export class ShotTrackerService {
 
   private listenForPossessionChange(): void {
     this.ballPossessionService.whenPossessionChanged((player) => {
-      if (!this.currentlyTrackedShot) return;
+      if (!this.currentlyTrackedShot) { return; }
 
       this.reportShotInterceptedBy(player);
     });
@@ -41,7 +41,7 @@ export class ShotTrackerService {
 
   private listenForGoals(): void {
     this.goalDetectionService.whenGoalDetected((unused) => {
-      if (!this.currentlyTrackedShot) return;
+      if (!this.currentlyTrackedShot) { return; }
 
       this.reportShotSuccessful();
     });


### PR DESCRIPTION
The problem occured when a player took a shot, caught up to the ball somehow and then took a shot again. This was because the possession service would not publish that reposession of the ball as a new possession changed event. Publishing such an event now will make the shottracker mark the already existing shot as a miss.