### PR TITLE
Fix goal scoring bug

### DIFF
--- a/src/services/ball_possession_service.ts
+++ b/src/services/ball_possession_service.ts
@@ -67,7 +67,9 @@ export class BallPossessionService implements IBallPossessionService {
   }
 
   private publishPossesionChangedEvents(playerInPossession: Player): void {
-    if (!this.currentPlayerInPossession) {
+    if (!this.lastPlayerInPossession) { return; }
+
+    if (this.lastPlayerInPossession !== playerInPossession) {
       this.queue.trigger(
           `${this.eventTag()}.possessionChanged`, playerInPossession);
     }

--- a/src/stats/shot_tracker_service.ts
+++ b/src/stats/shot_tracker_service.ts
@@ -23,6 +23,7 @@ export class ShotTrackerService {
 
   public track(shot: IShot): void {
     this.checkEnabled();
+    this.handleDoubleShotEdgeCase(shot);
     this.checkCurrentlyTrackedShot();
     this.currentlyTrackedShot = shot;
   }
@@ -75,6 +76,15 @@ export class ShotTrackerService {
   private checkEnabled(): void {
     if (!this.enabled) {
       throw new Error("ShotTrackerService not yet enabled.");
+    }
+  }
+
+  private handleDoubleShotEdgeCase(shot: IShot): void {
+    if (!this.currentlyTrackedShot) return;
+    if (this.currentlyTrackedShot.shooter === shot.shooter) {
+      // handle edge case where shooter shoots multiple times without possession
+      // changing to another user.
+      this.reportShotInterceptedBy(shot.shooter);
     }
   }
 }


### PR DESCRIPTION
https://github.com/Dirichi/football/pull/154 is a lie lol.  This is a better fix. The previous cl did not take into account that the ballpossession service always erases the currentPlayerInPossession, so a possessionChangedEvent will always be published.